### PR TITLE
Adopted hexo-generator-robotstxt to hexo3 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+hexo-generator-robotstxt.iml

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ robotstxt:
   - /one_file_to_disallow.html
   - /2nd_file_to_disallow.html
   - /3rd_file_to_disallow.html
-``` yaml
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hexo-generator-robotstxt
 
-A very simple plugin to generate a robots.txt file automatically for [Hexo](https://npmjs.org/package/hexo).
+A very simple plugin to generate a robots.txt file automatically for [Hexo 3](https://npmjs.org/package/hexo).
 
 ## Usage
 
@@ -18,6 +18,16 @@ Add `hexo-generator-robotstxt` to `plugins` in `_config.yml`.
 plugins:
 - hexo-generator-robotstxt
 ```
+
+Add config for `robots.txt` to `_config.yml`.
+``` yaml
+robotstxt:
+  useragent: "*"
+  disallow:
+  - /one_file_to_disallow.html
+  - /2nd_file_to_disallow.html
+  - /3rd_file_to_disallow.html
+``` yaml
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
-var util = hexo.util,
-    file = util.file,
-    extend = hexo.extend,
-    route = hexo.route;
-
-extend.generator.register(function(locals, render, callback){
-    route.set("robots.txt", "User-agent: *");
-    callback();
+hexo.extend.generator.register('robotstxt', function(locals){
+	return {
+		path: 'robots.txt',
+		data: function(){
+			var cfg = hexo.config.robotstxt;
+			var body = "User-agent: " + cfg.useragent + "\n";
+			cfg.disallow.forEach(function(entry) {
+				body += "Disallow: " + entry + "\n";
+			});
+			return body;
+		}
+	};
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Lee Crossley <leee@hotmail.co.uk> (http://ilee.co.uk/)",
   "description": "Basic robots.txt generator plugin for Hexo",
   "homepage": "http://ilee.co.uk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "index.js",
   "keywords": [
     "hexo",
@@ -14,6 +14,10 @@
     {
       "name": "Lee Crossley",
       "email": "leee@hotmail.co.uk"
+    },
+    {
+      "name": "Oliver Tönse",
+      "email": "oliver.toense@getima.net"
     }
   ],
   "repository": {
@@ -21,7 +25,7 @@
     "url": "https://github.com/leecrossley/hexo-generator-robotstxt"
   },
   "engines": {
-    "hexo": ">= 1.0.x",
+    "hexo": ">= 3.0.x",
     "node": ">= 0.8.x"
   }
 }


### PR DESCRIPTION
I found hexo-generator-robotstxt not working any more for hexo version 3.
So I adopted the code and during this implemented a feature to make the generated file configurable.

Would be nice to have this code registered as a new version in npmjs in future.
